### PR TITLE
Fix big_time fonttools

### DIFF
--- a/watchfaces/big_time/fonttools/font2png.py
+++ b/watchfaces/big_time/fonttools/font2png.py
@@ -60,7 +60,7 @@ META_DATA_TEMPLATE = \
 """
         {
         "type": "png",
-        "defName": "IMAGE_NUM_%d",
+        "name": "IMAGE_NUM_%d",
         "file": "images/num_%d.png"
         }"""
 


### PR DESCRIPTION
These two tweaks were necessary to get font2png.py to run successfully locally.
