### PR TITLE
Destroy window and layers in Simplicity watchface

### DIFF
--- a/watchfaces/simplicity/src/simplicity.c
+++ b/watchfaces/simplicity/src/simplicity.c
@@ -46,6 +46,10 @@ void handle_minute_tick(struct tm *tick_time, TimeUnits units_changed) {
 
 void handle_deinit(void) {
   tick_timer_service_unsubscribe();
+  layer_destroy(line_layer);
+  text_layer_destroy(text_time_layer);
+  text_layer_destroy(text_date_layer);
+  window_destroy(window);
 }
 
 void handle_init(void) {


### PR DESCRIPTION
The SDK example for Simplicity watchface doesn't destroy any layers nor windows. Is this the correct way to do it?

Is this a memory leak (I don't know if there is some default cleanup for watchfaces...)

If its a memory leak, would you mind sharing if the pre-bundled Simplicity watchface has the same bug? That might explain some of the issues I've been having with my watch...

Cheers!